### PR TITLE
Add HTML recommendations page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>外卖推荐合集</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }
+        h2 { margin-top: 2em; }
+        h3 { margin: 1em 0 0.5em; }
+        ul { list-style-type: none; padding: 0; }
+        li { margin-bottom: 0.5em; }
+    </style>
+</head>
+<body>
+    <h1>剧本杀店铺附近优质外卖推荐</h1>
+
+    <section>
+        <h2>MF·幕坊演绎</h2>
+        <h3>食品</h3>
+        <ul>
+            <li><strong>美味炸鸡店</strong> - 炸鸡酥脆，分量足，性价比高</li>
+            <li><strong>老妈米线</strong> - 汤底鲜美，辣味适中</li>
+        </ul>
+        <h3>饮品</h3>
+        <ul>
+            <li><strong>小乔奶茶</strong> - 甜度可调，口味多样</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>玉米叔剧本杀制片厂南山店</h2>
+        <h3>食品</h3>
+        <ul>
+            <li><strong>快餐便当王</strong> - 种类丰富，适合团餐</li>
+        </ul>
+        <h3>饮品</h3>
+        <ul>
+            <li><strong>鲜果饮品屋</strong> - 新鲜水果现榨</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>JM沉浸式剧本杀体验馆</h2>
+        <h3>食品</h3>
+        <ul>
+            <li><strong>李戈戈东北大碗麻辣烫</strong> - 分量足，推荐麻酱口味</li>
+        </ul>
+        <h3>饮品</h3>
+        <ul>
+            <li><strong>咖啡站</strong> - 多种咖啡选择</li>
+        </ul>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `index.html` page using HTML5
- organize recommendations by script store with food and beverage sections

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f5db953c8322aaaea9d217685e7d